### PR TITLE
partially reverted default bootstrap table style

### DIFF
--- a/web/src/main/resources/static/index.html
+++ b/web/src/main/resources/static/index.html
@@ -8,6 +8,7 @@
     <link href="lib/css/jquery.qtip.min.css" type="text/css" rel="stylesheet" />
     <link href="lib/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
     <link href="lib/css/bootstrap.pagination.css" type="text/css" rel="stylesheet" />
+    <link href="lib/css/bootstrap.table.css" type="text/css" rel="stylesheet" />
     <link href="lib/css/dataTables.bootstrap.min.css" type="text/css" rel="stylesheet" />
     <!--link href="lib/css/dataTables.jqueryui.min.css" type="text/css" rel="stylesheet" />
     <link href="lib/css/jquery.dataTables.min.css" type="text/css" rel="stylesheet" /-->

--- a/web/src/main/resources/static/lib/css/bootstrap.table.css
+++ b/web/src/main/resources/static/lib/css/bootstrap.table.css
@@ -1,0 +1,45 @@
+/*
+ * Bootstrap v3.3.6 (http://getbootstrap.com)
+ * Copyright 2011-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+
+/* (Partial) Default table style to revert the bootswatch style */
+
+.table > thead > tr > th,
+.table > tbody > tr > th,
+.table > tfoot > tr > th,
+.table > thead > tr > td,
+.table > tbody > tr > td,
+.table > tfoot > tr > td {
+    padding: 8px;
+    line-height: 1.42857143;
+    vertical-align: top;
+    border-top: 1px solid #ddd;
+}
+.table > thead > tr > th {
+    vertical-align: bottom;
+    border-bottom: 2px solid #ddd;
+}
+.table > caption + thead > tr:first-child > th,
+.table > colgroup + thead > tr:first-child > th,
+.table > thead:first-child > tr:first-child > th,
+.table > caption + thead > tr:first-child > td,
+.table > colgroup + thead > tr:first-child > td,
+.table > thead:first-child > tr:first-child > td {
+    border-top: 0;
+}
+.table > tbody + tbody {
+    border-top: 2px solid #ddd;
+}
+.table .table {
+    background-color: #fff;
+}
+.table-condensed > thead > tr > th,
+.table-condensed > tbody > tr > th,
+.table-condensed > tfoot > tr > th,
+.table-condensed > thead > tr > td,
+.table-condensed > tbody > tr > td,
+.table-condensed > tfoot > tr > td {
+    padding: 5px;
+}


### PR DESCRIPTION
The bootstrap table styles included with the freelancer template removes all the table borders.
This PR partially reverts default bootstrap table style.