### PR TITLE
Workaround for rendering of excluded columns

### DIFF
--- a/webapp/src/main/resources/static/src/js/util/ViewUtils.js
+++ b/webapp/src/main/resources/static/src/js/util/ViewUtils.js
@@ -299,6 +299,12 @@ var ViewUtils = (function() {
                 if (!isExcluded) {
                     includedCols.push(column);
                 }
+
+                // TODO workaround for a DataTables issue: even if the column is initially invisible,
+                // DataTables still call all available render functions at init!
+                if (isExcluded) {
+                    delete(column.createdCell);
+                }
             });
         }
 


### PR DESCRIPTION
This a partial workaround for excluded columns in the DataTable.
Ideal solution is to completely disable rendering for excluded columns.