### PR TITLE
Get table search string from URL before initialising

### DIFF
--- a/webapp/src/main/resources/static/src/js/view/HotspotTableView.js
+++ b/webapp/src/main/resources/static/src/js/view/HotspotTableView.js
@@ -151,6 +151,16 @@ function HotspotTableView(options)
         };
     }
 
+    function getTableSearchStringFromUrlParams()
+    {
+        var parts = window.location.href.split("?");
+        if(parts.length == 2) {
+            var params = new URLSearchParams(parts[1]);
+            return params.get("search");
+        }
+        return null;
+    }
+
     function render()
     {
         // TODO allow customization of renderer instances
@@ -343,6 +353,14 @@ function HotspotTableView(options)
         else
         {
             dataTableOpts.data = _options.data;
+        }
+
+        // pre-populate the table search field if URL has ?search=some_search_string
+        var search = getTableSearchStringFromUrlParams();
+        if(search) {
+            dataTableOpts.search = {
+                search: search
+            };
         }
 
         var table = $(_options.el).DataTable(dataTableOpts);


### PR DESCRIPTION
This PR enables a feature on the home page to pre-populate the table search with a string provided as part of the URL.

This allows external resources to link to a specific residue on cancerhotspots.org e.g.

https://www.cancerhotspots.org/#/home?search=KRAS%20Q61

will pre-populate the search with "KRAS Q61" such that when the table loads only that gene and residue will be shown.

I have tested this using a local HTTP server (changing the API URLs to point to https://www.cancerhotspots.org as appropriate).